### PR TITLE
Use correct content for phone field on contact edit page

### DIFF
--- a/resources/views/people/edit.blade.php
+++ b/resources/views/people/edit.blade.php
@@ -139,7 +139,7 @@
               {{-- Phone --}}
               <div class="form-group">
                 <label for="phone">{{ trans('people.information_edit_phone') }}</label>
-                <input class="form-control" name="phone" id="phone" value="{{ $contact->phone }}">
+                <input class="form-control" name="phone" id="phone" value="{{ $contact->phone_number }}">
               </div>
 
               {{-- Facebook --}}


### PR DESCRIPTION
Fixes #579 "Bug: When a phone is set, if I update the profile the phone is lost".

### Checklist

- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Make sure that the change you propose is the smallest possible.
- [ ] Screenshots are included if the PR changes the UI.
- [ ] Tests added for this feature/bug.
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [x] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
